### PR TITLE
Improve Mobile Responsiveness: Stacked Layout, Spacing, Sticky Headers (Closes #6)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -25,3 +25,71 @@ body {
 .kanban-task .task-actions button {
   margin-left: 4px;
 }
+
+/* Mobile responsiveness */
+@media (max-width: 576px) {
+  /* Stacked layout: one column per row */
+  #kanban-board {
+    display: block;
+    overflow-x: visible;
+    padding: 0 12px 12px 12px;
+    scroll-snap-type: none;
+  }
+
+  /* Each column fills width */
+  #kanban-board > .col-md-4 {
+    flex: 0 0 100%;
+    max-width: 100%;
+    scroll-snap-align: unset;
+  }
+
+  .kanban-column {
+    min-height: auto;
+    overflow-y: visible;
+    padding: 2.5rem;
+  }
+
+  .kanban-task {
+    padding: 14px 16px;
+    margin-bottom: 12px;
+    font-size: 16px;
+  }
+
+  .kanban-task .task-actions button {
+    padding: 8px 10px;
+  }
+
+  /* Sticky column headers for context while scrolling */
+  .card .card-header {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
+
+  /* spacing between stacked cards */
+  #kanban-board .card {
+    margin-bottom: 20px;
+  }
+  #kanban-board .card:last-child {
+    margin-bottom: 0;
+  }
+
+  /* Tighter heading spacing and size */
+  h1 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  /* imprv readability of task titles on wrap */
+  .kanban-task .task-title {
+    line-height: 1.3;
+    word-break: break-word;
+  }
+}
+
+/* improve touch behavior on coarse pointers */
+@media (hover: none) and (pointer: coarse) {
+  .kanban-task {
+    cursor: default; /* to avoid misleadibng grab cursor on touch */
+  }
+}


### PR DESCRIPTION
Switches to a stacked, single-column layout on phones with increased spacing and sticky headers. 
Improves tap targets and text wrapping for readability. 
No desktop regressions. 
Closes #6.